### PR TITLE
Correct dockerfile to use requirements.in

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 
 RUN apt update && apt upgrade -y
-COPY frontend/requirements.txt /requirements.txt
+COPY frontend/requirements.in /requirements.txt
 RUN pip install --no-cache-dir -r /requirements.txt
 
 COPY /frontend /app/frontend

--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,14 @@
 FROM python:3.11-slim
 
 RUN apt update && apt upgrade -y
-COPY frontend/requirements.in /requirements.txt
-RUN pip install --no-cache-dir -r /requirements.txt
 
+COPY frontend/requirements.in /requirements.in
+
+RUN pip install pip-tools && \
+    pip-compile requirements.in && \
+    pip-sync
+ 
 COPY /frontend /app/frontend
-
+ 
 WORKDIR /app/frontend
 CMD python -m dash_app


### PR DESCRIPTION
Intuition:

The versions are locked in the docker image. And we won't need to use a frozen requirements.txt file.